### PR TITLE
Fix Windows runtime binary loading crash

### DIFF
--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
@@ -66,5 +66,17 @@ public final class TestBasicFeatures {
         System.out.println("Compressed library path: " + loader.getNativeDynamicLibrary().getCompressedLibrary());
         System.out.println("Extracted library absolute path: " + loader.getNativeDynamicLibrary().getExtractedLibrary());
         System.out.println("Is Extracted: " + loader.getNativeDynamicLibrary().isExtracted());        
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(6000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            
+        }).start();
     }
 }

--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
@@ -66,17 +66,5 @@ public final class TestBasicFeatures {
         System.out.println("Compressed library path: " + loader.getNativeDynamicLibrary().getCompressedLibrary());
         System.out.println("Extracted library absolute path: " + loader.getNativeDynamicLibrary().getExtractedLibrary());
         System.out.println("Is Extracted: " + loader.getNativeDynamicLibrary().isExtracted());        
-
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    Thread.sleep(6000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }).start();
     }
 }

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -170,7 +170,15 @@ public final class NativeBinaryLoader {
         try {
             System.load(library.getExtractedLibrary());
         } catch (final UnsatisfiedLinkError error) {
-            error.printStackTrace();
+            switch (criteria) {
+                case RETRY_WITH_INCREMENTAL_EXTRACTION:
+                    incrementalExtractBinary(library);
+                    break;
+                
+                default:
+                    cleanExtractBinary(library);
+                    break;
+            }
         }
     }
     
@@ -202,10 +210,10 @@ public final class NativeBinaryLoader {
     private void cleanExtractBinary(NativeDynamicLibrary library) throws IOException {
             libraryExtractor = initializeLibraryExtractor(library);
             libraryExtractor.extract();
-            loadBinary(library, RetryCriteria.RETRY_WITH_CLEAN_EXTRACTION);
             /* CLEAR RESOURCES AND RESET OBJECTS */
             libraryExtractor.setExtractionListener(() -> {
                 try{
+                    loadBinary(library, RetryCriteria.RETRY_WITH_CLEAN_EXTRACTION);
                     libraryExtractor.getFileLocator().close();
                     libraryExtractor.close();
                     libraryExtractor = null;

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -216,6 +216,7 @@ public final class NativeBinaryLoader {
             /* CLEAR RESOURCES AND RESET OBJECTS */
             libraryExtractor.getFileLocator().close();
             libraryExtractor.close();
+            libraryExtractor = null;
         }
     }
 

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.lang.UnsatisfiedLinkError;
-
-import com.avrsandbox.snaploader.file.ExtractionListener;
 import com.avrsandbox.snaploader.file.FileExtractor;
 import com.avrsandbox.snaploader.library.LibraryExtractor;
 
@@ -214,16 +212,13 @@ public final class NativeBinaryLoader {
             libraryExtractor.extract();
             loadBinary(library, RetryCriteria.RETRY_WITH_CLEAN_EXTRACTION);
             /* CLEAR RESOURCES AND RESET OBJECTS */
-            libraryExtractor.setExtractionListener(new ExtractionListener() {
-                @Override
-                public void onExtractionCompleted() {
-                    try {
-                        libraryExtractor.getFileLocator().close();
-                        libraryExtractor.close();
-                        libraryExtractor = null;
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
+            libraryExtractor.setExtractionListener(() -> {
+                try{
+                    libraryExtractor.getFileLocator().close();
+                    libraryExtractor.close();
+                    libraryExtractor = null;
+                } catch (IOException e) {
+                    e.printStackTrace();
                 }
             });
     }

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -170,15 +170,7 @@ public final class NativeBinaryLoader {
         try {
             System.load(library.getExtractedLibrary());
         } catch (final UnsatisfiedLinkError error) {
-            switch (criteria) {
-                case RETRY_WITH_INCREMENTAL_EXTRACTION:
-                    incrementalExtractBinary(library);
-                    break;
-                
-                default:
-                    cleanExtractBinary(library);
-                    break;
-            }
+            error.printStackTrace();
         }
     }
     

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeDynamicLibrary.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeDynamicLibrary.java
@@ -160,7 +160,7 @@ public enum NativeDynamicLibrary {
      * @return a string representing the library path within the jar compression
      */
     public String getCompressedLibrary() {
-        return libraryDirectory + fileSeparator + library;
+        return libraryDirectory + "/" + library;
     }
 
     /**

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/file/ExtractionListener.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/file/ExtractionListener.java
@@ -1,0 +1,5 @@
+package com.avrsandbox.snaploader.file;
+
+public interface ExtractionListener {
+    void onExtractionCompleted();
+}

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/file/FileExtractor.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/file/FileExtractor.java
@@ -52,6 +52,8 @@ public class FileExtractor implements OutputStreamProvider {
     
     protected OutputStream fileOutputStream;
 
+    protected ExtractionListener extractionListener;
+
     /**
      * An absolute path for the destination file of the extraction process.
      */
@@ -94,6 +96,9 @@ public class FileExtractor implements OutputStreamProvider {
                 fileOutputStream.write(buffer, 0, bytes);
             }
         } finally {
+            if (extractionListener != null) {
+                extractionListener.onExtractionCompleted();
+            }
             lock.unlock();
             /* CRITICAL SECTION ENDS */
         }
@@ -113,5 +118,9 @@ public class FileExtractor implements OutputStreamProvider {
     @Override
     public InputStreamProvider getFileLocator() {
         return fileLocator;
+    }
+
+    public void setExtractionListener(ExtractionListener extractionListener) {
+        this.extractionListener = extractionListener;
     }
 }


### PR DESCRIPTION
This PR modifies the `snaploader-examples` to test thread wait for Windows.