### PR TITLE
jSnapLoader-core: platform libs - opened NativeVariant and internal optimizations

### DIFF
--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
@@ -65,7 +65,7 @@ public final class TestBasicFeatures {
         loader.setRetryWithCleanExtraction(true);
         /* Native dynamic library properties */
         printDetails(loader);
-        loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
+        loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
     }
 
     protected static void printDetails(NativeBinaryLoader loader) {

--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
@@ -34,6 +34,7 @@ package com.avrsandbox.snaploader.examples;
 import java.io.IOException;
 import com.avrsandbox.snaploader.LibraryInfo;
 import com.avrsandbox.snaploader.NativeBinaryLoader;
+import com.avrsandbox.snaploader.platform.NativeVariant;
 import com.avrsandbox.snaploader.LoadingCriterion;
 
 /**
@@ -58,14 +59,26 @@ public final class TestBasicFeatures {
 
     public static void main(String[] args) throws IOException {
         if (loader == null) {
-            loader = new NativeBinaryLoader(libraryInfo);
+            loader = new NativeBinaryLoader(libraryInfo).initPlatformLibrary();
         }
-        loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
+        loader.setLoggingEnabled(true);
+        loader.setRetryWithCleanExtraction(true);
         /* Native dynamic library properties */
+        printDetails(loader);
+        loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
+    }
+
+    protected static void printDetails(NativeBinaryLoader loader) {
+        System.out.println("--------------------------------------------------------------");
+        System.out.println("OS: " + NativeVariant.NAME.getProperty());
+        System.out.println("ARCH: " + NativeVariant.ARCH.getProperty());
+        System.out.println("VM: " + NativeVariant.VM.getProperty());
+        System.out.println("--------------------------------------------------------------");
         System.out.println("Jar Path: " + loader.getNativeDynamicLibrary().getJarPath());
         System.out.println("Library Directory: " + loader.getNativeDynamicLibrary().getLibraryDirectory());
         System.out.println("Compressed library path: " + loader.getNativeDynamicLibrary().getCompressedLibrary());
         System.out.println("Extracted library absolute path: " + loader.getNativeDynamicLibrary().getExtractedLibrary());
-        System.out.println("Is Extracted: " + loader.getNativeDynamicLibrary().isExtracted());        
+        System.out.println("Is Extracted: " + loader.getNativeDynamicLibrary().isExtracted()); 
+        System.out.println("--------------------------------------------------------------");
     }
 }

--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestBasicFeatures.java
@@ -65,7 +65,7 @@ public final class TestBasicFeatures {
         loader.setRetryWithCleanExtraction(true);
         /* Native dynamic library properties */
         printDetails(loader);
-        loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
+        loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
     }
 
     protected static void printDetails(NativeBinaryLoader loader) {

--- a/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestMultiThreading.java
+++ b/snaploader-examples/src/main/java/com/avrsandbox/snaploader/examples/TestMultiThreading.java
@@ -34,7 +34,6 @@ package com.avrsandbox.snaploader.examples;
 import java.io.IOException;
 import com.avrsandbox.snaploader.LoadingCriterion;
 import com.avrsandbox.snaploader.ConcurrentNativeBinaryLoader;
-import com.avrsandbox.snaploader.NativeDynamicLibrary;
 import com.avrsandbox.snaploader.UnSupportedSystemError;
 
 /**
@@ -86,13 +85,10 @@ public final class TestMultiThreading {
         }
     }, "Thread-Three");
 
-    public static void main(String[] args) {
-        TestBasicFeatures.loader = new ConcurrentNativeBinaryLoader(TestBasicFeatures.libraryInfo);
-        final NativeDynamicLibrary nativeDynamicLibrary = TestBasicFeatures.loader.getNativeDynamicLibrary();
-        // System.out.println("Jar file path: " + nativeDynamicLibrary.getJarPath());
-        // System.out.println("Library directory: " + nativeDynamicLibrary.getLibraryDirectory());
-        // System.out.println("Compressed library: " + nativeDynamicLibrary.getCompressedLibrary());
-        // System.out.println("Proposed extracted library: " + nativeDynamicLibrary.getExtractedLibrary());
+    public static void main(String[] args) throws UnSupportedSystemError, IOException {
+        TestBasicFeatures.loader = new ConcurrentNativeBinaryLoader(TestBasicFeatures.libraryInfo).initPlatformLibrary();
+        TestBasicFeatures.loader.setLoggingEnabled(true);
+        TestBasicFeatures.printDetails(TestBasicFeatures.loader);
         
         thread0.start();
         thread1.start();

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/LibraryInfo.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/LibraryInfo.java
@@ -31,6 +31,8 @@
  */
 package com.avrsandbox.snaploader;
 
+import com.avrsandbox.snaploader.platform.NativeDynamicLibrary;
+
 /**
  * Provides a library placeholder with an adjustable baseName {@link LibraryInfo#baseName}.
  * 

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -226,6 +226,7 @@ public class NativeBinaryLoader {
                 return;
             }
             System.load(library.getExtractedLibrary());
+            log(Level.INFO, "loadBinary", "Successfully loaded library: " + library.getExtractedLibrary(), null);
         } catch (final UnsatisfiedLinkError error) {
             log(Level.SEVERE, "loadBinary", "Cannot load the dynamic library: " + library.getExtractedLibrary(), error);
             /* Retry with clean extract */
@@ -247,11 +248,11 @@ public class NativeBinaryLoader {
         /* CLEAR RESOURCES AND RESET OBJECTS ON-EXTRACTION */
         libraryExtractor.setExtractionListener(() -> {
             try{
-                loadBinary(library);
                 libraryExtractor.getFileLocator().close();
                 libraryExtractor.close();
                 libraryExtractor = null;
                 log(Level.INFO, "cleanExtractBinary", "Extracted successfully to " + library.getExtractedLibrary(), null);
+                loadBinary(library);
             } catch (Exception e) {
                 log(Level.SEVERE, "cleanExtractBinary", "Error while closing the resources!", e);
             }

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/NativeBinaryLoader.java
@@ -277,6 +277,7 @@ public class NativeBinaryLoader {
      * Log data with a level and a throwable (optional).
      * 
      * @param level the logger level
+     * @param sourceMethod the source of this call
      * @param msg a string formatted message to display 
      * @param throwable optional param for error messages
      */

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/platform/NativeDynamicLibrary.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/platform/NativeDynamicLibrary.java
@@ -29,9 +29,10 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.avrsandbox.snaploader;
+package com.avrsandbox.snaploader.platform;
 
 import java.io.File;
+import com.avrsandbox.snaploader.LibraryInfo;
 
 /**
  * Represents a native binary domain with a {@link NativeDynamicLibrary#libraryDirectory} and a {@link NativeDynamicLibrary#library}.
@@ -41,6 +42,7 @@ import java.io.File;
  * @author pavl_g
  */
 public enum NativeDynamicLibrary {
+    
     /**
      * Represents a linux x86 binary with 64-bit instruction set.
      */
@@ -98,7 +100,7 @@ public enum NativeDynamicLibrary {
      * 
      * @param libraryInfo wraps abstract data representing the native library
      */
-    static void initWithLibraryInfo(LibraryInfo libraryInfo) {
+    public static void initWithLibraryInfo(LibraryInfo libraryInfo) {
         /* Initializes the library basename */
         if (libraryInfo.getBaseName() != null) {
             NativeDynamicLibrary.LINUX_x86.library = "lib" + libraryInfo.getBaseName() + ".so";

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/platform/NativeVariant.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/platform/NativeVariant.java
@@ -29,14 +29,14 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.avrsandbox.snaploader;
+package com.avrsandbox.snaploader.platform;
 
 /**
  * Represents a native variant (OS + ARCH + VM), each of which is represented as an object of a property.
  * 
  * @author pavl_g
  */
-enum NativeVariant {
+public enum NativeVariant {
     
     /**
      * The Operating system name property for this variant.

--- a/snaploader/src/main/java/com/avrsandbox/snaploader/platform/package-info.java
+++ b/snaploader/src/main/java/com/avrsandbox/snaploader/platform/package-info.java
@@ -29,42 +29,8 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.avrsandbox.snaploader;
-
-import java.io.IOException;
-import java.util.concurrent.locks.ReentrantLock;
-import com.avrsandbox.snaploader.platform.NativeDynamicLibrary;
 
 /**
- * A thread-safe implementation for the NativeBinaryLoader.
- * 
- * @author pavl_g
+ * Provides platform-dependent specifications to handle the abstract interface for the jSnapLoader.
  */
-public class ConcurrentNativeBinaryLoader extends NativeBinaryLoader {
-
-    /**
-     * The monitor object.
-     */
-    protected final ReentrantLock lock = new ReentrantLock();
-
-    /**
-     * Instantiates a thread-safe {@link NativeBinaryLoader} object.
-     * 
-     * @param libraryInfo a data structure object holding the platform independent data for the library to load
-     */
-    public ConcurrentNativeBinaryLoader(LibraryInfo libraryInfo) {
-        super(libraryInfo);
-    }
-    
-    @Override
-    protected void cleanExtractBinary(NativeDynamicLibrary library) throws IOException {
-        try {
-            /* CRITICAL SECTION STARTS */
-            lock.lock();
-            super.cleanExtractBinary(library);
-        } finally {
-            lock.unlock();
-            /* CRITICAL SECTION ENDS */
-        }
-    }
-}
+package com.avrsandbox.snaploader.platform;


### PR DESCRIPTION
This PR adds the following code optimizations: 
- [x] NativeVariant: opened the API for public use.
- [x] NativeDynamicLibrary: refactored to `com.avrsandbox.snaploader.platform` package.
- [x] NativeBinaryLoader: better utilizing the platform-dependent API.
- [x] snaploader-examples: utilizing retry criterion and the platform-dependent API.