### PR TITLE
Epsilon-patch: introduced a sanity-check of the stream provider handler for other File locator routines

### DIFF
--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestBasicFeatures.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestBasicFeatures.java
@@ -66,7 +66,7 @@ public final class TestBasicFeatures {
             DefaultDynamicLibraries.MAC_X86_64,
     };
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         if (loader == null) {
             loader = new NativeBinaryLoader(libraryInfo);
         }

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestBasicFeatures2.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestBasicFeatures2.java
@@ -53,7 +53,7 @@ import electrostatic4j.snaploader.LoadingCriterion;
  */
 public final class TestBasicFeatures2 {
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
 
         final Path compressionPath = Paths.get(PropertiesProvider.USER_DIR.getSystemProperty(), "libs", TestBasicFeatures.getJarFile());
         final Path extractionPath = Files.createDirectories(Paths.get(PropertiesProvider.USER_DIR.getSystemProperty(), "libs", 

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestFilesystemException.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestFilesystemException.java
@@ -15,7 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public final class TestFilesystemException {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         final Path compressionPath = Paths.get(PropertiesProvider.USER_DIR.getSystemProperty(), "libs", TestBasicFeatures.getJarFile());
         final Path extractionPath = Files.createDirectories(Paths.get(PropertiesProvider.USER_DIR.getSystemProperty(), "libs",
                 NativeVariant.OS_NAME.getProperty(), NativeVariant.OS_ARCH.getProperty()));

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestFilesystemMemoryLeak.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestFilesystemMemoryLeak.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
  * @author pavl_g
  */
 public class TestFilesystemMemoryLeak {
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         /* Locates the image inside the Zip Compression */
         SnapLoaderLogger.setLoggingEnabled(true);
         final FileLocator fileLocator = new FileLocator(getZipAbsolutePath(), getFilePath(), ZipCompressionType.ZIP);

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestMultiThreading.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestMultiThreading.java
@@ -55,7 +55,7 @@ public final class TestMultiThreading {
                 try {
                     Thread.sleep(200);
                     TestBasicFeatures.loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
-                } catch (UnSupportedSystemError | IOException | InterruptedException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }
@@ -69,7 +69,7 @@ public final class TestMultiThreading {
                 try {
                     Thread.sleep(200);
                     TestBasicFeatures.loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
-                } catch (UnSupportedSystemError | IOException | InterruptedException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }
@@ -83,7 +83,7 @@ public final class TestMultiThreading {
                 try {
                     Thread.sleep(200);
                     TestBasicFeatures.loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
-                } catch (UnSupportedSystemError | IOException | InterruptedException e) {
+                } catch (Exception e) {
                     e.printStackTrace();
                 }
             }

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestMultipleLoads.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestMultipleLoads.java
@@ -42,7 +42,7 @@ import java.io.IOException;
  */
 public final class TestMultipleLoads {
     
-    public static void main(String[] args) throws InterruptedException, IOException {
+    public static void main(String[] args) throws Exception {
         TestBasicFeatures.main(args);
         new File(TestBasicFeatures.getNativeDynamicLibraryPath()).delete();
         Thread.sleep(5000);

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestZipExtractor.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestZipExtractor.java
@@ -48,7 +48,7 @@ import electrostatic4j.snaploader.throwable.FilesystemResourceScavengingExceptio
  */
 public class TestZipExtractor {
      
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         /* Locates the image inside the Zip Compression */
         final FileLocator fileLocator = new FileLocator(getZipAbsolutePath(), getFilePath(), ZipCompressionType.ZIP);
         /* Extracts the image filesystem from the Zip Compression */

--- a/snaploader/src/main/java/electrostatic4j/snaploader/ConcurrentNativeBinaryLoader.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/ConcurrentNativeBinaryLoader.java
@@ -32,7 +32,6 @@
 
 package electrostatic4j.snaploader;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import electrostatic4j.snaploader.platform.NativeDynamicLibrary;
@@ -59,7 +58,7 @@ public class ConcurrentNativeBinaryLoader extends NativeBinaryLoader {
     }
     
     @Override
-    protected void cleanExtractBinary(NativeDynamicLibrary library) throws IOException {
+    protected void cleanExtractBinary(NativeDynamicLibrary library) throws Exception {
         try {
             /* CRITICAL SECTION STARTS */
             lock.lock();

--- a/snaploader/src/main/java/electrostatic4j/snaploader/NativeBinaryLoader.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/NativeBinaryLoader.java
@@ -152,7 +152,7 @@ public class NativeBinaryLoader {
      * @return this instance for chained invocations
      * @throws IOException if the library to extract is not present in the jar filesystem
      */
-    public NativeBinaryLoader loadLibrary(LoadingCriterion criterion) throws IOException {
+    public NativeBinaryLoader loadLibrary(LoadingCriterion criterion) throws Exception {
         if (criterion == LoadingCriterion.INCREMENTAL_LOADING && nativeDynamicLibrary.isExtracted()) {
             loadBinary(nativeDynamicLibrary);
             return this;
@@ -240,7 +240,7 @@ public class NativeBinaryLoader {
      * @param library the platform-specific library to load
      * @throws IOException in case the binary to be extracted is not found on the specified jar
      */
-    protected void loadBinary(NativeDynamicLibrary library) throws IOException {
+    protected void loadBinary(NativeDynamicLibrary library) throws Exception {
         try {
             /* sanity-check for android java vm (the dalvik) */
             if (NativeVariant.Os.isAndroid()) {
@@ -278,7 +278,7 @@ public class NativeBinaryLoader {
      * @throws IOException in case the binary to be extracted is not found on the specified jar, or an
      *                     interrupted I/O operation has occurred
      */
-    protected void cleanExtractBinary(NativeDynamicLibrary library) throws IOException {
+    protected void cleanExtractBinary(NativeDynamicLibrary library) throws Exception {
         libraryExtractor = initializeLibraryExtractor(library);
        SnapLoaderLogger.log(Level.INFO, getClass().getName(), "cleanExtractBinary",
                "File extractor handler initialized!");
@@ -346,7 +346,7 @@ public class NativeBinaryLoader {
      * @return a new FileExtractor object that represents an output stream provider
      * @throws IOException if the jar filesystem to be located is not found, or if the extraction destination is not found
      */
-    protected FileExtractor initializeLibraryExtractor(NativeDynamicLibrary library) throws IOException {
+    protected FileExtractor initializeLibraryExtractor(NativeDynamicLibrary library) throws Exception {
         FileExtractor extractor;
         if (library.getJarPath() != null) {
             extractor = new LibraryExtractor(library.getJarPath(), library.getCompressedLibrary(), library.getExtractedLibrary());

--- a/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/FileExtractor.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/FileExtractor.java
@@ -86,7 +86,12 @@ public class FileExtractor implements OutputStreamProvider {
     }
 
     @Override
-    public void initialize(int size) {
+    public void initialize(int size) throws Exception {
+        // 1) sanity-check for double initializing
+        // 2) sanity-check for pre-initialization using other routines
+        if (this.fileOutputStream != null) {
+            return;
+        }
         try {
             if (size > 0) {
                 this.fileOutputStream = new BufferedOutputStream(
@@ -98,7 +103,8 @@ public class FileExtractor implements OutputStreamProvider {
             this.fileOutputStream = new FileOutputStream(destination);
             SnapLoaderLogger.log(Level.INFO, getClass().getName(), "initialize(int)",
                     "File extractor initialized with hash key #" + getHashKey());
-        } catch (FileNotFoundException e) {
+        } catch (Exception e) {
+            close();
             throw new FilesystemResourceInitializationException(
                     "Failed to initialize the file extractor handler #" + getHashKey(), e);
         }

--- a/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/FileLocator.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/FileLocator.java
@@ -92,7 +92,13 @@ public class FileLocator implements InputStreamProvider {
 
 
     @Override
-    public void initialize(int size) {
+    public void initialize(int size) throws IOException {
+        // 1) sanity-check for double initializing
+        // 2) sanity-check for pre-initialization using other routines
+        // (e.g., classpath resources stream).
+        if (this.fileInputStream != null) {
+            return;
+        }
         try {
             final ZipFile compression = compressionType.createNewCompressionObject(directory);
             final ZipEntry zipEntry = compression.getEntry(filePath);
@@ -106,7 +112,8 @@ public class FileLocator implements InputStreamProvider {
             this.fileInputStream = compression.getInputStream(zipEntry);
             SnapLoaderLogger.log(Level.INFO, getClass().getName(), "initialize(int)",
                     "File locator initialized with hash key #" + getHashKey());
-        } catch (IOException e) {
+        } catch (Exception e) {
+            close();
             throw new FilesystemResourceInitializationException(
                     "Failed to initialize the file locator handler #" + getHashKey(), e);
         }

--- a/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/StreamProvider.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/filesystem/StreamProvider.java
@@ -46,7 +46,7 @@ public interface StreamProvider extends AutoCloseable {
      * @param size the size of the buffered IO in bytes or zero
      *             for auto filesystem size
      */
-    void initialize(int size);
+    void initialize(int size) throws Exception;
 
     /**
      * Generates a unique hash key for this object


### PR DESCRIPTION
This PR guards the `StreamProvider#initialize(int)` against other non-nullary stream providers routines (e.g., the use of classpath routine in `LibraryLocator#init<>(String)`).