### PR TITLE
NativeVariant.Cpu: add the capability to detect instruction-set extensions

### DIFF
--- a/snaploader-examples/build.gradle
+++ b/snaploader-examples/build.gradle
@@ -26,6 +26,12 @@ tasks.register("TestBasicFeatures2") {
     application.mainClass = 'electrostatic4j.snaploader.examples.TestBasicFeatures2'
 }
 
+tasks.register("TestCpuFeatures", JavaExec) {
+    classpath sourceSets.main.runtimeClasspath
+    description = 'Runs the TestCpuFeatures example app.'
+    mainClass = 'electrostatic4j.snaploader.examples.TestCpuFeatures'
+}
+
 tasks.register("MonitorableExample") {
     application.mainClass = 'electrostatic4j.snaploader.examples.MonitorableExample'
 }

--- a/snaploader-examples/build.gradle
+++ b/snaploader-examples/build.gradle
@@ -86,4 +86,11 @@ task createJar(type : Jar, dependsOn : copyLibs){
 
 dependencies {
     implementation project(path: ':snaploader')
+    implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3'
+
+    implementation 'com.github.stephengold:jolt-jni-Linux64:0.9.7'
+    runtimeOnly 'com.github.stephengold:jolt-jni-Linux64:0.9.7:DebugSp'
+    runtimeOnly 'com.github.stephengold:jolt-jni-Linux64_fma:0.9.7:DebugSp'
+    runtimeOnly 'com.github.stephengold:jolt-jni-Windows64:0.9.7:DebugSp'
+    runtimeOnly 'com.github.stephengold:jolt-jni-Windows64_avx2:0.9.7:DebugSp'
 }

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestCpuFeatures.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestCpuFeatures.java
@@ -84,7 +84,7 @@ public final class TestCpuFeatures {
         loader.setLoggingEnabled(true);
         loader.setRetryWithCleanExtraction(true);
         try {
-            loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
+            loader.loadLibrary(LoadingCriterion.CLEAN_EXTRACTION);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to load the joltjni library!");
         }

--- a/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestCpuFeatures.java
+++ b/snaploader-examples/src/main/java/electrostatic4j/snaploader/examples/TestCpuFeatures.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, The Electrostatic-Sandbox Distributed Simulation Framework, jSnapLoader
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of 'AvrSandbox' nor the names of its contributors
+ *   may be used to endorse or promote products derived from this software
+ *   without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package electrostatic4j.snaploader.examples;
+
+import com.github.stephengold.joltjni.Jolt;
+import electrostatic4j.snaploader.LibraryInfo;
+import electrostatic4j.snaploader.LoadingCriterion;
+import electrostatic4j.snaploader.NativeBinaryLoader;
+import electrostatic4j.snaploader.filesystem.DirectoryPath;
+import electrostatic4j.snaploader.platform.NativeDynamicLibrary;
+import electrostatic4j.snaploader.platform.util.NativeVariant;
+import electrostatic4j.snaploader.platform.util.PlatformPredicate;
+
+/**
+ * Tests selection between native libraries based on CPU features.
+ *
+ * @author Stephen Gold sgold@sonic.net
+ */
+public final class TestCpuFeatures {
+
+    public static void main(String[] argv) {
+        // Test for each of the relevant CPU features:
+        System.out.println("avx    = " + NativeVariant.Cpu.hasExtensions("avx"));
+        System.out.println("avx2   = " + NativeVariant.Cpu.hasExtensions("avx2"));
+        System.out.println("bmi1   = " + NativeVariant.Cpu.hasExtensions("bmi1"));
+        System.out.println("f16c   = " + NativeVariant.Cpu.hasExtensions("f16c"));
+        System.out.println("fma    = " + NativeVariant.Cpu.hasExtensions("fma"));
+        System.out.println("sse4_1 = " + NativeVariant.Cpu.hasExtensions("sse4_1"));
+        System.out.println("sse4_2 = " + NativeVariant.Cpu.hasExtensions("sse4_2"));
+
+        // Define a custom predicate for Linux with all 7 CPU features:
+        PlatformPredicate linuxWithFma = new PlatformPredicate(
+                PlatformPredicate.LINUX_X86_64,
+                "avx", "avx2", "bmi1", "f16c", "fma", "sse4_1", "sse4_2");
+        System.out.println("linuxWithFma    = " + linuxWithFma.evaluatePredicate());
+
+        // Define a custom predicate for Windows with 4 CPU features:
+        PlatformPredicate windowsWithAvx2 = new PlatformPredicate(
+                PlatformPredicate.WIN_X86_64,
+                "avx", "avx2", "sse4_1", "sse4_2");
+        System.out.println("windowsWithAvx2 = " + windowsWithAvx2.evaluatePredicate());
+        System.out.flush();
+
+        LibraryInfo info = new LibraryInfo(
+                new DirectoryPath("linux/x86-64/com/github/stephengold"),
+                "joltjni", DirectoryPath.USER_DIR);
+        NativeBinaryLoader loader = new NativeBinaryLoader(info);
+        NativeDynamicLibrary[] libraries = {
+            new NativeDynamicLibrary("linux/x86-64-fma/com/github/stephengold", linuxWithFma), // must precede vanilla LINUX_X86_64
+            new NativeDynamicLibrary("linux/x86-64/com/github/stephengold", PlatformPredicate.LINUX_X86_64),
+            new NativeDynamicLibrary("windows/x86-64-avx2/com/github/stephengold", windowsWithAvx2), // must precede vanilla WIN_X86_64
+            new NativeDynamicLibrary("windows/x86-64/com/github/stephengold", PlatformPredicate.WIN_X86_64)
+        };
+        loader.registerNativeLibraries(libraries).initPlatformLibrary();
+        loader.setLoggingEnabled(true);
+        loader.setRetryWithCleanExtraction(true);
+        try {
+            loader.loadLibrary(LoadingCriterion.INCREMENTAL_LOADING);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to load the joltjni library!");
+        }
+        System.err.flush();
+
+        // Invoke native code to obtain the configuration of the native library.
+        String configuration = Jolt.getConfigurationString();
+        /*
+         * Depending which native library was loaded, the configuration string
+         * should be one of the following:
+         *
+         * On LINUX_X86_64 platforms, either
+         *  Single precision x86 64-bit with instructions: SSE2 SSE4.1 SSE4.2 AVX AVX2 F16C LZCNT TZCNT FMADD (Debug Renderer) (16-bit ObjectLayer) (Assertions) (ObjectStream) (Debug) (C++ RTTI) (C++ Exceptions)
+         * or
+         *  Single precision x86 64-bit with instructions: SSE2 (Debug Renderer) (16-bit ObjectLayer) (Assertions) (ObjectStream) (Debug) (C++ RTTI) (C++ Exceptions)
+         *
+         * On WIN_X86_64 platforms, either
+         *  Single precision x86 64-bit with instructions: SSE2 SSE4.1 SSE4.2 AVX AVX2 F16C LZCNT TZCNT (FP Exceptions) (Debug Renderer) (16-bit ObjectLayer) (Assertions) (ObjectStream) (Debug) (C++ RTTI) (C++ Exceptions)
+         * or
+         *  Single precision x86 64-bit with instructions: SSE2 (FP Exceptions) (Debug Renderer) (16-bit ObjectLayer) (Assertions) (ObjectStream) (Debug) (C++ RTTI) (C++ Exceptions)
+         */
+        System.out.println(configuration);
+    }
+}

--- a/snaploader/build.gradle
+++ b/snaploader/build.gradle
@@ -27,5 +27,5 @@ jar { // assemble jar options [java -jar]
 }
 
 dependencies {
-    implementation('com.github.oshi:oshi-core:6.7.0')
+    api('com.github.oshi:oshi-core:6.7.0')
 }

--- a/snaploader/build.gradle
+++ b/snaploader/build.gradle
@@ -27,5 +27,5 @@ jar { // assemble jar options [java -jar]
 }
 
 dependencies {
-
+    implementation('com.github.oshi:oshi-core:6.7.0')
 }

--- a/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
@@ -303,7 +303,7 @@ public enum NativeVariant {
          * <p>
          * Extension names are case-insensitive and might be reported
          * differently by different operating systems or even by different
-         * versions of the same operating system.<p>
+         * versions of the same operating system.
          * <p>
          * Examples of extension names:<ul>
          * <li>"3dnow" for AMD 3D-Now</li>
@@ -327,7 +327,7 @@ public enum NativeVariant {
          * <li>"v82_dp" for Arm V8.2 DP</li>
          * <li>"v83_jscvt" for Arm v8.3 JSCVT</li>
          * <li>"v83_lrcpc" for Arm v8.3 LRCPC</li>
-         * </ul></p>
+         * </ul>
          * <p>
          * Wikipedia provides informal descriptions of many ISA extensions.
          * https://en.wikipedia.org/wiki/Template:Multimedia_extensions offers a

--- a/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
@@ -300,6 +300,38 @@ public enum NativeVariant {
 
         /**
          * Tests whether the named ISA extensions are all present.
+         * <p>
+         * Extension names are case-insensitive and might be reported
+         * differently by different operating systems or even by different
+         * versions of the same operating system.<p>
+         * <p>
+         * Examples of extension names:<ul>
+         * <li>"3dnow" for AMD 3D-Now</li>
+         * <li>"avx" for x86 AVX</li>
+         * <li>"avx2" for x86 AVX2</li>
+         * <li>"avx512f" for x86 AVX512F</li>
+         * <li>"bmi1" for x86 bit-manipulation instruction set 1</li>
+         * <li>"f16c" for x86 half-precision floating-point</li>
+         * <li>"fma" for x86 fused multiply-add</li>
+         * <li>"fmac" for Arm floating-point multiply-accumulate</li>
+         * <li>"mmx" for x86 MMX</li>
+         * <li>"neon" for Arm NEON</li>
+         * <li>"sse3" for x86 SSE3</li>
+         * <li>"sse4_1" for x86 SSE4.1</li>
+         * <li>"sse4_2" for x86 SSE4.2</li>
+         * <li>"ssse3" for x86 SSSE3</li>
+         * <li>"v8" for Arm V8</li>
+         * <li>"v8_crc32" for Arm V8 extra CRC32</li>
+         * <li>"v8_crypto" for Arm V8 extra cryptographic</li>
+         * <li>"v81_atomic" for Arm V8.1 atomic</li>
+         * <li>"v82_dp" for Arm V8.2 DP</li>
+         * <li>"v83_jscvt" for Arm v8.3 JSCVT</li>
+         * <li>"v83_lrcpc" for Arm v8.3 LRCPC</li>
+         * </ul></p>
+         * <p>
+         * Wikipedia provides informal descriptions of many ISA extensions.
+         * https://en.wikipedia.org/wiki/Template:Multimedia_extensions offers a
+         * good starting point.
          *
          * @param requiredNames the names of the extensions to test for
          * @return {@code true} if the current platform supports all of the

--- a/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
@@ -91,15 +91,6 @@ public enum NativeVariant {
 
     private final String property;
 
-    /**
-     * named CPU features that were detected by the OSHI library
-     */
-    private static Collection<String> presentFeatures;
-    /**
-     * serialize access to presentFeatures
-     */
-    private static Object synchronizeFeatures = new Object();
-
     NativeVariant(final String property) {
         this.property = property;
     }
@@ -151,6 +142,15 @@ public enum NativeVariant {
      * A namespace class exposing the CPU propositions.
      */
     public static final class Cpu {
+        /**
+         * named CPU features that were detected by the OSHI library
+         */
+        private static Collection<String> presentFeatures;
+        /**
+         * serialize access to presentFeatures
+         */
+        private static Object synchronizeFeatures = new Object();
+
         private Cpu() {
         }
 

--- a/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/NativeVariant.java
@@ -287,6 +287,13 @@ public enum NativeVariant {
             // Convert the list to a collection of feature names:
             Collection<String> result = new TreeSet<>();
             for (String oshiString : oshiList) {
+                /*
+                 * On macOS, strings ending with ": 0" indicate
+                 * disabled features, so ignore all such lines.
+                 */
+                if (oshiString.endsWith(": 0")) {
+                    continue;
+                }
                 String lcString = oshiString.toLowerCase(Locale.ROOT);
                 Matcher matcher = pattern.matcher(lcString);
                 while (matcher.find()) {

--- a/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/PlatformPredicate.java
+++ b/snaploader/src/main/java/electrostatic4j/snaploader/platform/util/PlatformPredicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, The Electrostatic-Sandbox Distributed Simulation Framework, jSnapLoader
+ * Copyright (c) 2023-2025, The Electrostatic-Sandbox Distributed Simulation Framework, jSnapLoader
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,6 +132,19 @@ public final class PlatformPredicate {
      */
     public PlatformPredicate(boolean predicate) {
         this.predicate = predicate;
+    }
+
+    /**
+     * Instantiates a predicate object that combines a pre-existing predicate
+     * with one or more instruction-set extensions.  The result is true if and
+     * only if the base predicate is true and all named extensions are present.
+     *
+     * @param base a pre-existing predicate (not null)
+     * @param isaExtensions names of required ISA extensions
+     */
+    public PlatformPredicate(PlatformPredicate base, String... isaExtensions) {
+        this.predicate = base.evaluatePredicate()
+                && NativeVariant.Cpu.hasExtensions(isaExtensions);
     }
 
     /**


### PR DESCRIPTION
Here's my first cut at a solution for issue #36.  I use [the OSHI library](https://github.com/oshi/oshi) to obtain CPU feature information. Any X86 ISA extensions that are present are cached in a private `TreeSet` that can be used to define custom predicates, like so:

```java
        PlatformPredicate linuxWithHaswell = new PlatformPredicate(
                PlatformPredicate.LINUX_X86_64.evaluatePredicate()
                && NativeVariant.Cpu.hasExtensions("avx", "avx2", "bmi1", "f16c", "fma", "sse4_1", "sse4_2"));
```

I assume the dynamic libraries are searched in the order they are passed to `registerNativeLibraries()`, and the first match is used. That way I can use predefined platform predicates as a fallback, like so:

```java
       NativeBinaryLoader loader = new NativeBinaryLoader(info);
        NativeDynamicLibrary[] libraries = {
            new NativeDynamicLibrary("linux/x86-64/haswell", linuxWithHaswell),
            new NativeDynamicLibrary("linux/x86-64", PlatformPredicate.LINUX_X86_64)
        };
        loader.registerNativeLibraries(libraries).initPlatformLibrary();
```
with the assurance that "linux/x86-64" will be loaded only if `linuxWithHaswell` is `false`.